### PR TITLE
Indent output from Cargo

### DIFF
--- a/cargo/cli_runner.go
+++ b/cargo/cli_runner.go
@@ -65,8 +65,8 @@ func (c CLIRunner) InstallMember(memberPath string, srcDir string, destLayer lib
 		Command: "cargo",
 		Args:    args,
 		Dir:     srcDir,
-		Stdout:  c.Logger.InfoWriter(),
-		Stderr:  c.Logger.InfoWriter(),
+		Stdout:  bard.NewWriter(c.Logger.Logger.InfoWriter(), bard.WithIndent(3)),
+		Stderr:  bard.NewWriter(c.Logger.Logger.InfoWriter(), bard.WithIndent(3)),
 	}); err != nil {
 		return fmt.Errorf("unable to build\n%w", err)
 	}

--- a/cargo/cli_runner_test.go
+++ b/cargo/cli_runner_test.go
@@ -204,8 +204,7 @@ func testCLIRunner(t *testing.T, context spec.G, it spec.S) {
 			}
 			executor.On("Execute", mock.MatchedBy(func(ex effect.Execution) bool {
 				return reflect.DeepEqual(ex.Args, expectedArgs) &&
-					ex.Dir == workingDir &&
-					reflect.TypeOf(ex.Stdout) == reflect.TypeOf(logger.InfoWriter())
+					ex.Dir == workingDir
 			})).Return(nil)
 
 			runner := cargo.NewCLIRunner(
@@ -244,8 +243,7 @@ func testCLIRunner(t *testing.T, context spec.G, it spec.S) {
 				}
 				executor.On("Execute", mock.MatchedBy(func(ex effect.Execution) bool {
 					return reflect.DeepEqual(ex.Args, expectedArgs) &&
-						ex.Dir == workingDir &&
-						reflect.TypeOf(ex.Stdout) == reflect.TypeOf(logger.InfoWriter())
+						ex.Dir == workingDir
 				})).Return(nil)
 
 				runner := cargo.NewCLIRunner(
@@ -374,8 +372,7 @@ func testCLIRunner(t *testing.T, context spec.G, it spec.S) {
 			}
 			executor.On("Execute", mock.MatchedBy(func(ex effect.Execution) bool {
 				return reflect.DeepEqual(ex.Args, expectedArgs) &&
-					ex.Dir == workingDir &&
-					reflect.TypeOf(ex.Stdout) == reflect.TypeOf(logger.InfoWriter())
+					ex.Dir == workingDir
 			})).Return(fmt.Errorf("expected"))
 
 			runner := cargo.NewCLIRunner(


### PR DESCRIPTION
Indent output from commands which get executed. This keeps the output neat & tidy.