### PR TITLE
Fixes some typos in the README & CI workflows

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -7,7 +7,7 @@ codeowners:
   owner: "@paketo-community/rust-maintainers"
 
 package:
-  repository:     docker.io/paketocommunity/rust-dist
+  repository:     docker.io/paketocommunity/cargo
   register:       true
   registry_token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -150,7 +150,7 @@ jobs:
                     --format "${FORMAT}"
                 fi
               env:
-                PACKAGE: docker.io/paketocommunity/rust-dist
+                PACKAGE: docker.io/paketocommunity/cargo
                 PUBLISH: "true"
                 VERSION: ${{ steps.version.outputs.version }}
             - name: Update release with digest
@@ -178,7 +178,7 @@ jobs:
             - if: ${{ true }}
               uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1
               with:
-                address: docker.io/paketocommunity/rust-dist@${{ steps.package.outputs.digest }}
+                address: docker.io/paketocommunity/cargo@${{ steps.package.outputs.digest }}
                 id: paketo-community/cargo
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
                 version: ${{ steps.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `gcr.io/paketo-community/cargo`
+# `docker.io/paketocommunity/cargo`
 
 The Rust Cargo Buildpack is a Cloud Native Buildpack that builds Rust applications using Cargo.
 


### PR DESCRIPTION
- Fixes the image name in the README
- Fixes the location to which images are published by CI. A copy and paste error had it published to the wrong repo