### PR TITLE
Adds `/workspace/bin` to $PATH

### DIFF
--- a/cargo/cargo_test.go
+++ b/cargo/cargo_test.go
@@ -235,7 +235,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(outputLayer.LayerTypes.Cache).To(BeTrue())
 				Expect(outputLayer.LayerTypes.Build).To(BeFalse())
-				Expect(outputLayer.LayerTypes.Launch).To(BeFalse())
+				Expect(outputLayer.LayerTypes.Launch).To(BeTrue())
 
 				// app files should be deleted
 				Expect(appFile).ToNot(BeAnExistingFile())
@@ -249,6 +249,9 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				Expect(filepath.Join(outputLayer.Path, "bin", "my-binary")).To(BeARegularFile())
 				Expect(filepath.Join(ctx.Application.Path, "bin", "my-binary")).To(BeARegularFile())
 				Expect(filepath.Join(ctx.Application.Path, "mtimes.json")).ToNot(BeARegularFile())
+
+				// Ensure `/workspace/bin` is added to the PATH at launch
+				Expect(outputLayer.LaunchEnvironment["PATH.append"]).To(Equal(filepath.Join(ctx.Application.Path, "bin")))
 			})
 
 			it("contributes cargo layer with one member", func() {
@@ -273,7 +276,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(outputLayer.LayerTypes.Cache).To(BeTrue())
 				Expect(outputLayer.LayerTypes.Build).To(BeFalse())
-				Expect(outputLayer.LayerTypes.Launch).To(BeFalse())
+				Expect(outputLayer.LayerTypes.Launch).To(BeTrue())
 
 				// app files should be deleted
 				Expect(appFile).ToNot(BeAnExistingFile())
@@ -287,6 +290,9 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				Expect(filepath.Join(outputLayer.Path, "bin", "my-binary")).To(BeARegularFile())
 				Expect(filepath.Join(ctx.Application.Path, "bin", "my-binary")).To(BeARegularFile())
 				Expect(filepath.Join(ctx.Application.Path, "mtimes.json")).ToNot(BeARegularFile())
+
+				// Ensure `/workspace/bin` is added to the PATH at launch
+				Expect(outputLayer.LaunchEnvironment["PATH.append"]).To(Equal(filepath.Join(ctx.Application.Path, "bin")))
 			})
 
 			context("--path is set", func() {
@@ -316,7 +322,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 					Expect(outputLayer.LayerTypes.Cache).To(BeTrue())
 					Expect(outputLayer.LayerTypes.Build).To(BeFalse())
-					Expect(outputLayer.LayerTypes.Launch).To(BeFalse())
+					Expect(outputLayer.LayerTypes.Launch).To(BeTrue())
 
 					// app files should be deleted
 					Expect(appFile).ToNot(BeAnExistingFile())
@@ -330,6 +336,9 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 					Expect(filepath.Join(outputLayer.Path, "bin", "my-binary")).To(BeARegularFile())
 					Expect(filepath.Join(ctx.Application.Path, "bin", "my-binary")).To(BeARegularFile())
 					Expect(filepath.Join(ctx.Application.Path, "mtimes.json")).ToNot(BeARegularFile())
+
+					// Ensure `/workspace/bin` is added to the PATH at launch
+					Expect(outputLayer.LaunchEnvironment["PATH.append"]).To(Equal(filepath.Join(ctx.Application.Path, "bin")))
 				})
 			})
 
@@ -357,7 +366,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(outputLayer.LayerTypes.Cache).To(BeTrue())
 				Expect(outputLayer.LayerTypes.Build).To(BeFalse())
-				Expect(outputLayer.LayerTypes.Launch).To(BeFalse())
+				Expect(outputLayer.LayerTypes.Launch).To(BeTrue())
 
 				// app files should be deleted
 				Expect(appFile).ToNot(BeAnExistingFile())
@@ -378,6 +387,9 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				// make sure InstallMember ran three times
 				service.AssertNumberOfCalls(t, "InstallMember", 3)
+
+				// Ensure `/workspace/bin` is added to the PATH at launch
+				Expect(outputLayer.LaunchEnvironment["PATH.append"]).To(Equal(filepath.Join(ctx.Application.Path, "bin")))
 			})
 
 			it("fails cause CARGO_HOME isn't set", func() {
@@ -461,7 +473,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(outputLayer.LayerTypes.Cache).To(BeTrue())
 				Expect(outputLayer.LayerTypes.Build).To(BeFalse())
-				Expect(outputLayer.LayerTypes.Launch).To(BeFalse())
+				Expect(outputLayer.LayerTypes.Launch).To(BeTrue())
 
 				// app files should be deleted
 				Expect(appFile).ToNot(BeAnExistingFile())


### PR DESCRIPTION
Previously this path was not added to $PATH, thus you needed to use a full path to the binary to run it. Adding it to $PATH is a convenience that makes using Procfile and running installed commands easier.
This PR makes the following changes:

- We are appending to PATH as a launch environment variable with `/workspace/bin`
- The cargo layer is now launch + cache. It needs to be launch because we are setting a launch environment variable.
- Because we have the cargo layer at launch, this would have resulted in the installed binaries being in the container twice, once in the layer and once in `/workspace/bin`. We have switched from copying the binaries to `/workspace/bin` and are now symlinking them. This generally shouldn't result in a change of behavior from the end-user perspective.

Resolves #113