### PR TITLE
Add `tini` to launch processes

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -15,3 +15,13 @@ docker_credentials:
   - registry: docker.io
     username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
     password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+
+dependencies:
+- name:         Tini
+  id:           tini
+  uses:         docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
+  with:
+    glob:       tini-amd64
+    owner:      krallin
+    repository: tini
+    token:      ${{ secrets.JAVA_GITHUB_TOKEN }}

--- a/.github/workflows/update-tini.yml
+++ b/.github/workflows/update-tini.yml
@@ -1,0 +1,113 @@
+name: Update Tini
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v2
+              with:
+                go-version: "1.17"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                GO111MODULE=on go get -u -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v2
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
+              with:
+                glob: tini-amd64
+                owner: krallin
+                repository: tini
+                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |-
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
+              env:
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: ""
+                ID: tini
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: ""
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
+            - uses: peter-evans/create-pull-request@v3
+              with:
+                author: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }} <${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `Tini` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/tini
+                commit-message: |-
+                    Bump Tini from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps Tini from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump Tini from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ If all of these conditions are met:
 The buildpack will do the following:
 
 * Requests that Rust and Cargo be installed
+* If `$BP_CARGO_TINI_DISABLED` is false, `tini` is installed to the launch layer
 * Uses `CARGO_HOME` to locate Cargo & tools
 * Symlinks `<APPLICATION_ROOT/target>` to a cache layer, so that build artifacts are cached
 * Reads workspace members out of `Cargo.toml`
 * For each workspace member, it executes `cargo install` to build and install binaries. Binaries are installed to a layer marked with `cache`
 * All source code is removed from `/workspace`
-* The application binary is copied from the `cache` layer to `/workspace`
+* The application binaries are copied from the `cache` layer to `/workspace`
 * Cleans `CARGO_HOME` as described [in the Cargo book](https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci)
+* Reads binary targets from `Cargo.toml` and contributes process type for each target
+  * Each process type launches the target using `tini` so that PID1 signal handling works out-of-the-box
+  * If `$BP_CARGO_TINI_DISABLED` is set to true, `tini` will not be added to the process types
 
 ## Configuration
 
@@ -29,6 +33,7 @@ The buildpack will do the following:
 | `$BP_CARGO_INSTALL_ARGS`      | Additional arguments for `cargo install`. By default, the buildpack will run `cargo install --color=never --root=<destination layer> --path=<path-to-member>` for each workspace member. See more details below.                                                                                                                                                       |
 | `$BP_CARGO_WORKSPACE_MEMBERS` | A comma delimited list of the workspace package names (this is the package name in the member's `Cargo.toml`, not what is in the workspace's `Cargo.toml`'s member list) to install. If the project is not using workspaces, this is not used. By default, for projects with a workspace, the buildpack will build all members in a workspace. See more details below. |
 | `$BP_CARGO_EXCLUDE_FOLDERS`   | A comma delimited list of the top-level folders that should not be deleted, which means they will persist through to the generated image. This *only* applies to top level folders. You only need the folder name, not a full path.                                                                                                                                    |
+| `$BP_CARGO_TINI_DISABLED`     | Disable using `tini` to launch binary targets. Defaults to `false`, so `tini` is installed and used by default. Set to `true` and `tini` will not be installed or used.                                                                                                                                                                                                |
 
 ### `BP_CARGO_INSTALL_ARGS`
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,16 +1,58 @@
 api = "0.6"
 
 [buildpack]
-  id = "paketo-community/cargo"
-  name = "Rust Cargo Build Pack"
-  version  = "{{.version}}"
-  homepage = "https://github.com/paketo-community/cargo"
   description = "A Cloud Native Buildpack that builds Cargo-based Rust applications from source"
-  keywords    = ["cargo", "rust", "build-system"]
+  homepage = "https://github.com/paketo-community/cargo"
+  id = "paketo-community/cargo"
+  keywords = ["cargo", "rust", "build-system"]
+  name = "Rust Cargo Build Pack"
+  version = "{{.version}}"
 
-[[buildpack.licenses]]
-  type = "Apache-2.0"
-  uri  = "https://github.com/paketo-community/cargo/blob/main/LICENSE"
+  [[buildpack.licenses]]
+    type = "Apache-2.0"
+    uri = "https://github.com/paketo-community/cargo/blob/main/LICENSE"
+
+[metadata]
+  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "buildpack.toml"]
+  pre-package = "scripts/build.sh"
+
+  [[metadata.configurations]]
+    build = true
+    default = ""
+    description = "additional arguments to pass to Cargo install"
+    name = "BP_CARGO_INSTALL_ARGS"
+
+  [[metadata.configurations]]
+    build = true
+    default = ""
+    description = "the subset of workspace members for Cargo to install"
+    name = "BP_CARGO_WORKSPACE_MEMBERS"
+
+  [[metadata.configurations]]
+    build = true
+    default = "static, templates, public, html"
+    description = "folders that should not be deleted and should persist to the generated image"
+    name = "BP_CARGO_EXCLUDE_FOLDERS"
+
+  [[metadata.configurations]]
+    build = true
+    default = "false"
+    description = "Skip installing tini"
+    name = "BP_CARGO_TINI_DISABLED"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:tini_project:tini:0.19.0:*:*:*:*:*:*:*"]
+    id = "tini"
+    name = "Tini"
+    purl = "pkg:generic/tini@v0.19.0"
+    sha256 = "93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c"
+    stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
+    uri = "https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd64"
+    version = "0.19.0"
+
+    [[metadata.dependencies.licenses]]
+      type = "MIT"
+      uri = "https://github.com/krallin/tini/blob/master/LICENSE"
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
@@ -20,33 +62,3 @@ api = "0.6"
 
 [[stacks]]
   id = "*"
-
-[[metadata.configurations]]
-name        = "BP_CARGO_INSTALL_ARGS"
-description = "additional arguments to pass to Cargo install"
-default     = ""
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_CARGO_WORKSPACE_MEMBERS"
-description = "the subset of workspace members for Cargo to install"
-default     = ""
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_CARGO_EXCLUDE_FOLDERS"
-description = "folders that should not be deleted and should persist to the generated image"
-default     = "static, templates, public, html"
-build       = true
-
-[metadata]
-pre-package   = "scripts/build.sh"
-include-files = [
-  "LICENSE",
-  "NOTICE",
-  "README.md",
-  "bin/build",
-  "bin/detect",
-  "bin/main",
-  "buildpack.toml",
-]

--- a/cargo/cargo.go
+++ b/cargo/cargo.go
@@ -286,7 +286,7 @@ func (c Cargo) IsPathSet() (bool, error) {
 	return false, nil
 }
 
-func (c Cargo) BuildProcessTypes() ([]libcnb.Process, error) {
+func (c Cargo) BuildProcessTypes(tiniEnabled bool) ([]libcnb.Process, error) {
 	binaryTargets, err := c.CargoService.ProjectTargets(c.ApplicationPath)
 	if err != nil {
 		return []libcnb.Process{}, fmt.Errorf("unable to find project targets\n%w", err)
@@ -294,10 +294,16 @@ func (c Cargo) BuildProcessTypes() ([]libcnb.Process, error) {
 
 	procs := []libcnb.Process{}
 	for _, target := range binaryTargets {
+		command := filepath.Join(c.ApplicationPath, "bin", target)
+		args := []string{}
+		if tiniEnabled {
+			args = append([]string{"-g", "--", command}, args...)
+			command = "tini"
+		}
 		procs = append(procs, libcnb.Process{
 			Type:      target,
-			Command:   filepath.Join(c.ApplicationPath, "bin", target),
-			Arguments: []string{},
+			Command:   command,
+			Arguments: args,
 			Direct:    true,
 			Default:   false,
 		})

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/tini/init_test.go
+++ b/tini/init_test.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tini_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestUnitRustCargo(t *testing.T) {
+	suite := spec.New("Tini", spec.Report(report.Terminal{}))
+	suite("Tini", testTini)
+	suite.Run(t)
+}

--- a/tini/testdata/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.toml
+++ b/tini/testdata/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.toml
@@ -1,0 +1,2 @@
+uri = "https://localhost/stub-tini"
+sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/tini/tini.go
+++ b/tini/tini.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tini
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/buildpacks/libcnb"
+	"github.com/paketo-buildpacks/libpak"
+	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/paketo-buildpacks/libpak/sherpa"
+)
+
+type Tini struct {
+	LayerContributor libpak.DependencyLayerContributor
+	Logger           bard.Logger
+}
+
+func NewTini(dependency libpak.BuildpackDependency, cache libpak.DependencyCache) (Tini, libcnb.BOMEntry) {
+	contributor, entry := libpak.NewDependencyLayer(dependency, cache, libcnb.LayerTypes{
+		Launch: true,
+	})
+	return Tini{LayerContributor: contributor}, entry
+}
+
+func (d Tini) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
+	d.LayerContributor.Logger = d.Logger
+
+	return d.LayerContributor.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
+		d.Logger.Bodyf("Copying to %s", layer.Path)
+
+		err := os.MkdirAll(filepath.Join(layer.Path, "bin"), 0755)
+		if err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to make bin directory\n%w", err)
+		}
+
+		file := filepath.Join(layer.Path, "bin", "tini")
+		if err := sherpa.CopyFile(artifact, file); err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to copy artifact to %s\n%w", file, err)
+		}
+
+		if err := os.Chmod(file, 0755); err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to make tini executable\n%w", err)
+		}
+
+		return layer, nil
+	})
+}
+
+func (d Tini) Name() string {
+	return d.LayerContributor.LayerName()
+}

--- a/tini/tini_test.go
+++ b/tini/tini_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tini_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildpacks/libcnb"
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libpak"
+	"github.com/paketo-community/cargo/tini"
+	"github.com/sclevine/spec"
+)
+
+func testTini(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		ctx libcnb.BuildContext
+	)
+
+	it.Before(func() {
+		var err error
+
+		ctx.Layers.Path, err = ioutil.TempDir("", "distribution-layers")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(ctx.Layers.Path)).To(Succeed())
+	})
+
+	it("contributes tini", func() {
+		dep := libpak.BuildpackDependency{
+			URI:    "https://localhost/stub-tini",
+			SHA256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		}
+		dc := libpak.DependencyCache{CachePath: "testdata"}
+
+		d, _ := tini.NewTini(dep, dc)
+		layer, err := ctx.Layers.Layer("test-layer")
+		Expect(err).NotTo(HaveOccurred())
+
+		layer, err = d.Contribute(layer)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(layer.Build).To(BeFalse())
+		Expect(layer.Cache).To(BeFalse())
+		Expect(layer.Launch).To(BeTrue())
+		Expect(filepath.Join(layer.Path, "bin", "tini")).To(BeARegularFile())
+	})
+
+}


### PR DESCRIPTION
By default, the buildpack will install `tini` and configure process types to use `tini` to start your application. Your process runs as PID1, so this ensures that signals will work properly out-of-the-box. The `tini` binary is very small so this does not add a lot of size or overhead. If you do not need this behavior, you can disable it by setting `$BP_CARGO_TINI_DISABLED` to `true`.

This is installing `tini` directly instead of using the `tini` buildpack for a couple of reasons. First, we needed to make changes to this buildpack to support `tini` anyway, it is a only small bit of code, it ensures that output is consistent, and when we get to SBOM it will ensure that operates consistently with the rest of the buildpack.

Resolves https://github.com/paketo-community/rust/issues/155

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>