### PR TITLE
Enable sparse registry support.

### DIFF
--- a/cargo/cargo.go
+++ b/cargo/cargo.go
@@ -207,8 +207,11 @@ func (c Cargo) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("unable to find CARGO_HOME, it must be set")
 		}
 
-		err = preserver.RestoreAll(targetPath, cargoHome, layer.Path)
-		if err != nil {
+		if err := os.Setenv("CARGO_UNSTABLE_SPARSE_REGISTRY", "true"); err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to set CARGO_UNSTABLE_SPARSE_REGISTRY\n%w", err)
+		}
+
+		if err = preserver.RestoreAll(targetPath, cargoHome, layer.Path); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to restore all\n%w", err)
 		}
 

--- a/cargo/cargo_test.go
+++ b/cargo/cargo_test.go
@@ -293,6 +293,8 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				_, err = c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
 
+				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+
 				Expect(service.Calls[2].Method).To(Equal("InstallTool"))
 				Expect(service.Calls[2].Arguments[0]).To(Equal("foo-tool"))
 				Expect(service.Calls[2].Arguments[1]).To(Equal([]string{"--baz"}))
@@ -341,6 +343,8 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				outputLayer, err := c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
 
+				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+
 				sbomScanner.AssertCalled(t, "ScanLayer", inputLayer, ctx.Application.Path, libcnb.CycloneDXJSON, libcnb.SyftJSON)
 
 				Expect(outputLayer.LayerTypes.Cache).To(BeTrue())
@@ -386,6 +390,8 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				outputLayer, err := c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
 
+				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+
 				sbomScanner.AssertCalled(t, "ScanLayer", inputLayer, ctx.Application.Path, libcnb.CycloneDXJSON, libcnb.SyftJSON)
 
 				Expect(outputLayer.LayerTypes.Cache).To(BeTrue())
@@ -430,6 +436,8 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				outputLayer, err := c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
+
+				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
 
 				sbomScanner.AssertNotCalled(t, "ScanLayer", inputLayer, ctx.Application.Path, libcnb.CycloneDXJSON, libcnb.SyftJSON)
 
@@ -481,6 +489,8 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 					outputLayer, err := c.Contribute(inputLayer)
 					Expect(err).NotTo(HaveOccurred())
 
+					Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+
 					sbomScanner.AssertCalled(t, "ScanLayer", inputLayer, ctx.Application.Path, libcnb.CycloneDXJSON, libcnb.SyftJSON)
 
 					Expect(outputLayer.LayerTypes.Cache).To(BeTrue())
@@ -528,6 +538,8 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				outputLayer, err := c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
+
+				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
 
 				sbomScanner.AssertCalled(t, "ScanLayer", inputLayer, ctx.Application.Path, libcnb.CycloneDXJSON, libcnb.SyftJSON)
 
@@ -640,6 +652,8 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				outputLayer, err := c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
+
+				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
 
 				Expect(outputLayer.LayerTypes.Cache).To(BeTrue())
 				Expect(outputLayer.LayerTypes.Build).To(BeFalse())


### PR DESCRIPTION
Cargo has [recently enabled what is called sparse registry support](https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html) on nightly Rust. This will download crates.io information over HTTPS instead of Git. It is much faster because it's also able to only download what it needs for the project instead of the entire set of data from crates.io. See the link for more details.

This PR sets the environment variable to enable sparse registry support, which can decrease buildtimes significantly on the first run. This is only supported on nightly Rust at the moment, but the environment variable is safely ignored on stable. When it's supported on stable, it should just start working there as well.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>