### PR TITLE
Update Cargo/crates.io Sparse Index support

### DIFF
--- a/cargo/cargo.go
+++ b/cargo/cargo.go
@@ -216,8 +216,8 @@ func (c Cargo) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("unable to find CARGO_HOME, it must be set")
 		}
 
-		if err := os.Setenv("CARGO_UNSTABLE_SPARSE_REGISTRY", "true"); err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to set CARGO_UNSTABLE_SPARSE_REGISTRY\n%w", err)
+		if err := os.Setenv("CARGO_REGISTRIES_CRATES_IO_PROTOCOL", "sparse"); err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to set CARGO_REGISTRIES_CRATES_IO_PROTOCOL\n%w", err)
 		}
 
 		if err = preserver.RestoreAll(targetPath, cargoHome, layer.Path); err != nil {

--- a/cargo/cargo_test.go
+++ b/cargo/cargo_test.go
@@ -293,7 +293,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				_, err = c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+				Expect(os.Getenv("CARGO_REGISTRIES_CRATES_IO_PROTOCOL")).To(Equal("sparse"))
 
 				Expect(service.Calls[2].Method).To(Equal("InstallTool"))
 				Expect(service.Calls[2].Arguments[0]).To(Equal("foo-tool"))
@@ -343,7 +343,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				outputLayer, err := c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+				Expect(os.Getenv("CARGO_REGISTRIES_CRATES_IO_PROTOCOL")).To(Equal("sparse"))
 
 				sbomScanner.AssertCalled(t, "ScanLayer", inputLayer, ctx.Application.Path, libcnb.CycloneDXJSON, libcnb.SyftJSON)
 
@@ -390,7 +390,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				outputLayer, err := c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+				Expect(os.Getenv("CARGO_REGISTRIES_CRATES_IO_PROTOCOL")).To(Equal("sparse"))
 
 				sbomScanner.AssertCalled(t, "ScanLayer", inputLayer, ctx.Application.Path, libcnb.CycloneDXJSON, libcnb.SyftJSON)
 
@@ -437,7 +437,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				outputLayer, err := c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+				Expect(os.Getenv("CARGO_REGISTRIES_CRATES_IO_PROTOCOL")).To(Equal("sparse"))
 
 				sbomScanner.AssertNotCalled(t, "ScanLayer", inputLayer, ctx.Application.Path, libcnb.CycloneDXJSON, libcnb.SyftJSON)
 
@@ -489,7 +489,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 					outputLayer, err := c.Contribute(inputLayer)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+					Expect(os.Getenv("CARGO_REGISTRIES_CRATES_IO_PROTOCOL")).To(Equal("sparse"))
 
 					sbomScanner.AssertCalled(t, "ScanLayer", inputLayer, ctx.Application.Path, libcnb.CycloneDXJSON, libcnb.SyftJSON)
 
@@ -539,7 +539,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				outputLayer, err := c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+				Expect(os.Getenv("CARGO_REGISTRIES_CRATES_IO_PROTOCOL")).To(Equal("sparse"))
 
 				sbomScanner.AssertCalled(t, "ScanLayer", inputLayer, ctx.Application.Path, libcnb.CycloneDXJSON, libcnb.SyftJSON)
 
@@ -653,7 +653,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				outputLayer, err := c.Contribute(inputLayer)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(os.Getenv("CARGO_UNSTABLE_SPARSE_REGISTRY")).To(Equal("true"))
+				Expect(os.Getenv("CARGO_REGISTRIES_CRATES_IO_PROTOCOL")).To(Equal("sparse"))
 
 				Expect(outputLayer.LayerTypes.Cache).To(BeTrue())
 				Expect(outputLayer.LayerTypes.Build).To(BeFalse())


### PR DESCRIPTION
## Summary

The environment variable for Cargo/crates.io sparse index support has changed to `CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse`. This PR updates that functionality. It is still enabled by default, but requires beta or nightly Rust to work. This should just start working when upstream Rust supports this in stable.

## Use Cases

Faster builds, less data loaded when pulling necessary packages.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
