### PR TITLE
Change target selection to support ARM64

### DIFF
--- a/cargo/build_test.go
+++ b/cargo/build_test.go
@@ -18,7 +18,6 @@ package cargo_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,12 +44,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "build-application")
+		ctx.Application.Path = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "bin"), 0755)).ToNot(HaveOccurred())
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "build-layers")
+		ctx.Layers.Path = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx.Buildpack.Metadata = map[string]interface{}{

--- a/cargo/cache_test.go
+++ b/cargo/cache_test.go
@@ -17,7 +17,6 @@
 package cargo_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,10 +38,10 @@ func testCache(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		appDir, err = ioutil.TempDir("", "app-dir")
+		appDir = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "cache-layers")
+		ctx.Layers.Path = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/cargo/cargo_test.go
+++ b/cargo/cargo_test.go
@@ -18,7 +18,6 @@ package cargo_test
 
 import (
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -48,13 +47,13 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "cargo-layers")
+		ctx.Layers.Path = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
-		ctx.Application.Path, err = ioutil.TempDir("", "app-dir")
+		ctx.Application.Path = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
-		cargoHome, err = ioutil.TempDir("", "cargo-home")
+		cargoHome = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Setenv("CARGO_HOME", cargoHome)).ToNot(HaveOccurred())
 
@@ -83,7 +82,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "src"), 0755)).To(Succeed())
 			appFile = filepath.Join(ctx.Application.Path, "src", "main.rs")
-			Expect(ioutil.WriteFile(appFile, []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(appFile, []byte{}, 0644)).To(Succeed())
 		})
 
 		context("validate metadata", func() {
@@ -279,7 +278,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				service.On("WorkspaceMembers", mock.AnythingOfType("string"), mock.AnythingOfType("libcnb.Layer")).Return([]url.URL{}, nil)
 				service.On("Install", mock.AnythingOfType("string"), mock.AnythingOfType("libcnb.Layer")).Return(func(srcDir string, layer libcnb.Layer) error {
 					Expect(os.MkdirAll(filepath.Join(layer.Path, "bin"), 0755)).ToNot(HaveOccurred())
-					err := ioutil.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
+					err := os.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
 					Expect(err).ToNot(HaveOccurred())
 					return nil
 				})
@@ -329,7 +328,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 				service.On("WorkspaceMembers", mock.AnythingOfType("string"), mock.AnythingOfType("libcnb.Layer")).Return([]url.URL{}, nil)
 				service.On("Install", mock.AnythingOfType("string"), mock.AnythingOfType("libcnb.Layer")).Return(func(srcDir string, layer libcnb.Layer) error {
 					Expect(os.MkdirAll(filepath.Join(layer.Path, "bin"), 0755)).ToNot(HaveOccurred())
-					err := ioutil.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
+					err := os.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
 					Expect(err).ToNot(HaveOccurred())
 					return nil
 				})
@@ -375,7 +374,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				service.On("Install", mock.AnythingOfType("string"), mock.AnythingOfType("libcnb.Layer")).Return(func(srcDir string, layer libcnb.Layer) error {
 					Expect(os.MkdirAll(filepath.Join(layer.Path, "bin"), 0755)).ToNot(HaveOccurred())
-					err := ioutil.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
+					err := os.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
 					Expect(err).ToNot(HaveOccurred())
 					return nil
 				})
@@ -422,7 +421,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				service.On("Install", mock.AnythingOfType("string"), mock.AnythingOfType("libcnb.Layer")).Return(func(srcDir string, layer libcnb.Layer) error {
 					Expect(os.MkdirAll(filepath.Join(layer.Path, "bin"), 0755)).ToNot(HaveOccurred())
-					err := ioutil.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
+					err := os.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
 					Expect(err).ToNot(HaveOccurred())
 					return nil
 				})
@@ -474,7 +473,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 					service.On("Install", mock.AnythingOfType("string"), mock.AnythingOfType("libcnb.Layer")).Return(func(srcDir string, layer libcnb.Layer) error {
 						Expect(os.MkdirAll(filepath.Join(layer.Path, "bin"), 0755)).ToNot(HaveOccurred())
-						err := ioutil.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
+						err := os.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
 						Expect(err).ToNot(HaveOccurred())
 						return nil
 					})
@@ -524,7 +523,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				service.On("InstallMember", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("libcnb.Layer")).Return(func(memberPath string, srcDir string, layer libcnb.Layer) error {
 					Expect(os.MkdirAll(filepath.Join(layer.Path, "bin"), 0755)).ToNot(HaveOccurred())
-					err := ioutil.WriteFile(filepath.Join(layer.Path, "bin", filepath.Base(memberPath)), []byte("contents"), 0644)
+					err := os.WriteFile(filepath.Join(layer.Path, "bin", filepath.Base(memberPath)), []byte("contents"), 0644)
 					Expect(err).ToNot(HaveOccurred())
 					return nil
 				})
@@ -619,7 +618,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				for _, appFile := range append(appFilesKeep, appFilesGone...) {
 					Expect(os.MkdirAll(filepath.Dir(appFile), 0755)).To(Succeed())
-					Expect(ioutil.WriteFile(appFile, []byte{}, 0644)).To(Succeed())
+					Expect(os.WriteFile(appFile, []byte{}, 0644)).To(Succeed())
 				}
 
 				c, err = cargo.NewCargo(
@@ -638,7 +637,7 @@ func testCargo(t *testing.T, context spec.G, it spec.S) {
 
 				service.On("Install", mock.AnythingOfType("string"), mock.AnythingOfType("libcnb.Layer")).Return(func(srcDir string, layer libcnb.Layer) error {
 					Expect(os.MkdirAll(filepath.Join(layer.Path, "bin"), 0755)).ToNot(HaveOccurred())
-					err := ioutil.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
+					err := os.WriteFile(filepath.Join(layer.Path, "bin", "my-binary"), []byte("contents"), 0644)
 					Expect(err).ToNot(HaveOccurred())
 					return nil
 				})

--- a/cargo/detect_test.go
+++ b/cargo/detect_test.go
@@ -17,7 +17,6 @@
 package cargo_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "cargo")
+		ctx.Application.Path = t.TempDir()
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -50,7 +49,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	context("missing required files", func() {
 		it("missing Cargo.toml", func() {
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "Cargo.lock"), []byte{}, 0644))
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "Cargo.lock"), []byte{}, 0644))
 
 			plan, err := detect.Detect(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -58,7 +57,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("missing Cargo.lock", func() {
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "Cargo.toml"), []byte{}, 0644))
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "Cargo.toml"), []byte{}, 0644))
 
 			plan, err := detect.Detect(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -73,8 +72,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("passes with both Cargo.toml and Cargo.lock", func() {
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "Cargo.toml"), []byte{}, 0644))
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "Cargo.lock"), []byte{}, 0644))
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "Cargo.toml"), []byte{}, 0644))
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "Cargo.lock"), []byte{}, 0644))
 
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
 			Pass: true,

--- a/mtimes/mtimes_test.go
+++ b/mtimes/mtimes_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +45,7 @@ func testMTimes(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		workDir, err = ioutil.TempDir("", "mtimes-test")
+		workDir = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
 		mtimesTemplate, err = template.New("mtimes.json").ParseFiles("testdata/mtimes.json")
@@ -103,7 +102,7 @@ func testMTimes(t *testing.T, context spec.G, it spec.S) {
 			mtimesFile := filepath.Join(workDir, "testdata/mtimes.json")
 			Expect(mtimesFile).To(BeARegularFile())
 
-			buf, err := ioutil.ReadFile(mtimesFile)
+			buf, err := os.ReadFile(mtimesFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(buf)).To(ContainSubstring("testdata"))
 			Expect(string(buf)).To(ContainSubstring("testdata/folder1"))
@@ -131,7 +130,7 @@ func testMTimes(t *testing.T, context spec.G, it spec.S) {
 			var b bytes.Buffer
 			err := mtimesTemplate.Execute(&b, map[string]string{"WorkDir": workDir})
 			Expect(err).ToNot(HaveOccurred())
-			err = ioutil.WriteFile(filepath.Join(workDir, "testdata/mtimes.json"), b.Bytes(), 0644)
+			err = os.WriteFile(filepath.Join(workDir, "testdata/mtimes.json"), b.Bytes(), 0644)
 			Expect(err).ToNot(HaveOccurred())
 
 			preserver := mtimes.NewPreserver(bard.NewLogger(&logs))

--- a/tini/tini_test.go
+++ b/tini/tini_test.go
@@ -17,7 +17,6 @@
 package tini_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func testTini(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "distribution-layers")
+		ctx.Layers.Path = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
## Summary

Previously, the target selection on the tiny/static stacks would assume AMD64/x86_64. This PR changes the behavior to look at the current system architecture and select the correct target for the architecture running. It also enables the `BP_ARCH` environment variable which can be used to override the decision, although this is primarily for testing.

## Use Cases

Enables ARM64.
