### PR TITLE
Bugfix/alternative package-id

### DIFF
--- a/runner/runners.go
+++ b/runner/runners.go
@@ -253,11 +253,15 @@ func ParseWorkspaceMember(workspaceMember string) (string, string, string, error
 		}
 
 		otherHalf := strings.SplitN(half[1], "@", 2)
-		if len(otherHalf) != 2 {
-			return "", "", "", fmt.Errorf("unable to parse workspace member [%s], missing `@`", workspaceMember)
+		if len(otherHalf) == 2 {
+			return strings.TrimSpace(otherHalf[0]), strings.TrimSpace(otherHalf[1]), strings.TrimSpace(half[0]), nil
+		} else {
+			splitIndex := strings.LastIndex(half[0], "/")
+			path := half[0][:splitIndex]
+			pkgName := half[0][splitIndex+1:]
+			return strings.TrimSpace(pkgName), strings.TrimSpace(half[1]), strings.TrimSpace(path), nil
 		}
 
-		return strings.TrimSpace(otherHalf[0]), strings.TrimSpace(otherHalf[1]), strings.TrimSpace(half[0]), nil
 	} else {
 		// This is OK because the workspace member format is `package-name package-version (url)` and
 		//   none of name, version or URL may contain a space & be valid

--- a/runner/runners.go
+++ b/runner/runners.go
@@ -241,9 +241,12 @@ func (c CargoRunner) WorkspaceMembers(srcDir string, destLayer libcnb.Layer) ([]
 
 // parseWorkspaceMember parses a workspace member which can be in a couple of different formats
 //
-//	pre-1.77: `package-name package-version (url)`, like `function 0.1.0 (path+file:///Users/dmikusa/Downloads/fn-rs)`
-//	1.77+: `url#package-name@package-version` like `path+file:///Users/dmikusa/Downloads/fn-rs#function@0.1.0`
+//		pre-1.77: `package-name package-version (url)`, like `function 0.1.0 (path+file:///Users/dmikusa/Downloads/fn-rs)`
+//		1.77+:
+//	     - `url#package-name@package-version` like `path+file:///Users/dmikusa/Downloads/fn-rs#function@0.1.0`
+//	     - `url#version` for local packages where the workspace member name is equal to the directory name like `path+file:///Users/jondoe/.../services/example-transform#0.1.0`
 //
+// The final directory is assumed to be the package name with the local package format.
 // returns the package name, version, URL, and optional error in that order
 func ParseWorkspaceMember(workspaceMember string) (string, string, string, error) {
 	if strings.HasPrefix(workspaceMember, "path+file://") {

--- a/runner/runners_test.go
+++ b/runner/runners_test.go
@@ -471,6 +471,7 @@ func testRunners(t *testing.T, context spec.G, it spec.S) {
 							"path+file:///workspace/todo#todo@1.2.0",
 							"path+file:///workspace/routes#routes@0.5.0",
 							"path+file:///workspace/jokes#jokes@1.5.6",
+							"path+file:///workspace/other-format/other-format#1.0.0",
 						})
 
 					executor.On("Execute", mock.MatchedBy(func(ex effect.Execution) bool {
@@ -490,7 +491,7 @@ func testRunners(t *testing.T, context spec.G, it spec.S) {
 					urls, err := runner.WorkspaceMembers(workingDir, destLayer)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(urls).To(HaveLen(4))
+					Expect(urls).To(HaveLen(5))
 
 					url, err := url.Parse("path+file:///workspace/basics")
 					Expect(err).ToNot(HaveOccurred())
@@ -507,6 +508,10 @@ func testRunners(t *testing.T, context spec.G, it spec.S) {
 					url, err = url.Parse("path+file:///workspace/jokes")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(urls[3]).To(Equal(*url))
+
+					url, err = url.Parse("path+file:///workspace/other-format")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(urls[4]).To(Equal(*url))
 				})
 			})
 
@@ -830,15 +835,16 @@ func testRunners(t *testing.T, context spec.G, it spec.S) {
 				Expect(version).To(Equal("2.0.0"))
 				Expect(url).To(Equal("path+file:///workspace/basics"))
 			})
-
+			it("parses alternative package-id", func() {
+				pkgName, version, url, err := runner.ParseWorkspaceMember("path+file:///workspace/basics/basics#2.0.0")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pkgName).To(Equal("basics"))
+				Expect(version).To(Equal("2.0.0"))
+				Expect(url).To(Equal("path+file:///workspace/basics"))
+			})
 			it("fails to parse because there is no hash sign", func() {
 				_, _, _, err := runner.ParseWorkspaceMember("path+file:///workspace/basics")
 				Expect(err).To(MatchError("unable to parse workspace member [path+file:///workspace/basics], missing `#`"))
-			})
-
-			it("fails to parse because there is no at sign", func() {
-				_, _, _, err := runner.ParseWorkspaceMember("path+file:///workspace/basics#foo")
-				Expect(err).To(MatchError("unable to parse workspace member [path+file:///workspace/basics#foo], missing `@`"))
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This PR fixes an issue which occures while building a repo with workspaces.
Without this changes the builds fail with
```
[builder] unable to invoke layer creator
[builder] unable to contribute application layer
[builder] unable to fetch members
[builder] unable to parse: unable to parse workspace member [path+file:///workspace/services/example-store#0.1.0], missing `@`
[builder] ERROR: failed to build: exit status 1
ERROR: failed to build: executing lifecycle: failed with status code: 51
```
because if the folder of the workspace is named like the workspace-member the package-id is slightly different.
(Example 3 in https://doc.rust-lang.org/cargo/reference/pkgid-spec.html#example-specifications under Local packages )
An example for member with a different folder name and one example for a member with the same name as the folder:
```
  "workspace_members": [
    "path+file:///Users/jondoe/.../services/example-store#example-store2@0.1.0",
    "path+file:///Users/jondoe/.../services/example-transform#0.1.0"
  ],
```
## Use Cases
Fixing workspace builds

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
